### PR TITLE
Fix broken CDN links

### DIFF
--- a/updates.json
+++ b/updates.json
@@ -1,19 +1,19 @@
 {
     "latest": "1.3",
-    "latestURL": "https://cdn.discordapp.com/attachments/982673006042169344/990233867661238302/saffari.apk",
+    "latestURL": "https://cdn.hqapps.org/saffari1.3.apk",
     "channels": {
         "stable": {
             "name": "Saffari for androd",
             "description": "De originel Saffari! Itz susport tebs settiing favs history passwds and more! Androd 5plis nedend!!!",
-            "url": "https://saffari.tk",
+            "url": "https://saffari.hqapps.org",
             "latest": "1.3",
-            "latestURL": "https://cdn.discordapp.com/attachments/982673006042169344/990233867661238302/saffari.apk",
+            "latestURL": "https://cdn.hqapps.org/saffari1.3.apk",
             "versions": {
-                "1.3": "https://cdn.discordapp.com/attachments/982673006042169344/990233867661238302/saffari.apk",
-                "1.2.1": "https://cdn.discordapp.com/attachments/982673006042169344/986329407331373126/saffari.apk",
-                "1.2": "https://cdn.discordapp.com/attachments/982673006042169344/986295893651230740/saffari.apk",
-                "1.1.1": "https://cdn.discordapp.com/attachments/982673006042169344/982696364913864764/saffari.apk",
-                "1.1": "https://cdn.discordapp.com/attachments/982673006042169344/982686643242803271/saffari.apk",
+                "1.3": "https://cdn.hqapps.org/saffari1.3.apk",
+                "1.2.1": "https://cdn.hqapps.org/saffari1.2.1.apk",
+                "1.2": "https://cdn.hqapps.org/saffari1.2.apk",
+                "1.1.1": "https://cdn.hqapps.org/saffari1.1.1.apk",
+                "1.1": "https://cdn.hqapps.org/saffari1.1.apk",
                 "1.0": ""
             }
         },
@@ -30,10 +30,10 @@
             "description": "the Saffari for androd fro androd 4!! itz haz less feature and less updat butt itz aviable for andord 4 orr olda!",
             "url": "https://saffari.tk",
             "latest": "1.0.1",
-            "latestURL": "https://cdn.discordapp.com/attachments/982673006042169344/992084977581817896/saffari.apk",
+            "latestURL": "https://cdn.hqapps.org/saffarilegacy1.0.1.apk",
             "versions": {
-                "1.0.1": "https://cdn.discordapp.com/attachments/982673006042169344/992084977581817896/saffari.apk",
-                "1.0": "https://cdn.discordapp.com/attachments/982673006042169344/990235637615587328/saffari.apk"
+                "1.0.1": "https://cdn.hqapps.org/saffarilegacy1.0.1.apk",
+                "1.0": "https://cdn.hqapps.org/saffarilegacy1.0.apk"
             }
         },
         "notz": {
@@ -41,9 +41,9 @@
             "description": "NOTZ! de quikk and esyy not takink epplikation!! itz 100% lokal AND private !! No datat sent anyweree and no intrenett rekwired!",
             "url": "https://hqapps.tk/notz",
             "latest": "1.0",
-            "latestURL": "https://cdn.discordapp.com/attachments/982673006042169344/995336250993152020/notz.apk",
+            "latestURL": "https://cdn.hqapps.org/notz1.0.apk",
             "versions": {
-                "1.0": "https://cdn.discordapp.com/attachments/982673006042169344/995336250993152020/notz.apk"
+                "1.0": "https://cdn.hqapps.org/notz1.0.apk"
             }
         },
         "vibrator": {
@@ -51,9 +51,9 @@
             "description": "FUN!!!",
             "url": "https://hqapps.org/apps/vibrator",
             "latest": "1.0",
-            "latestURL": "https://cdn.discordapp.com/attachments/1082239768814948392/1110955326599082035/vibrator.apk",
+            "latestURL": "https://cdn.hqapps.org/vibrator1.0.apk",
             "versions": {
-                "1.0": "https://cdn.discordapp.com/attachments/1082239768814948392/1110955326599082035/vibrator.apk"
+                "1.0": "https://cdn.hqapps.org/vibrator1.0.apk"
             }
         }
     }


### PR DESCRIPTION
I replaced all broken cdn.discordapp.com links with our new cdn.hqapps.org links so HQDL works again.